### PR TITLE
Do not use Claim namespace anymore

### DIFF
--- a/package/composition.yaml
+++ b/package/composition.yaml
@@ -17,6 +17,7 @@ spec:
             name: in-cluster
           rollbackLimit: 0
           forProvider:
+            namespace: upbound-system
             skipCreateNamespace: true
             chart:
               name: platform-ref-apigateway-chart
@@ -29,19 +30,25 @@ spec:
               toConnectionSecretKey: restapi-arn
           writeConnectionSecretToRef:
             name: apigateway
+            namespace: upbound-system
       patches:
         - fromFieldPath: metadata.name
           toFieldPath: spec.forProvider.values.name
-        - fromFieldPath: spec.claimRef.namespace
-          toFieldPath: spec.forProvider.namespace
         - fromFieldPath: metadata.name
           toFieldPath: spec.connectionDetails[0].name
-        - fromFieldPath: spec.claimRef.namespace
-          toFieldPath: spec.writeConnectionSecretToRef.namespace
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.values.region
         - fromFieldPath: spec.parameters.resources
           toFieldPath: spec.forProvider.values.resources
+        - type: CombineFromComposite
+          combine:
+            variables:
+            - fromFieldPath: metadata.name
+            - fromFieldPath: metadata.uid
+            strategy: string
+            string:
+              fmt: apigateway-%s-%s
+          toFieldPath: spec.writeConnectionSecretToRef.name
     - name: secret2status
       base:
         apiVersion: kubernetes.crossplane.io/v1alpha1
@@ -55,12 +62,17 @@ spec:
               apiVersion: v1
               kind: Secret
               metadata:
-                # name in manifest is optional and defaults to Object name
-                name: apigateway
-                namespace: default
+                namespace: upbound-system
       patches:
-        - fromFieldPath: spec.claimRef.namespace
-          toFieldPath: spec.forProvider.namespace
+        - type: CombineFromComposite
+          combine:
+            variables:
+            - fromFieldPath: metadata.name
+            - fromFieldPath: metadata.uid
+            strategy: string
+            string:
+              fmt: apigateway-%s-%s
+          toFieldPath: spec.forProvider.manifest.metadata.name
         - type: ToCompositeFieldPath
           fromFieldPath: status.atProvider.manifest.data.restapi-arn
           toFieldPath: status.agw.restapi-arn


### PR DESCRIPTION


<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

* Use `upbound-system` namespace for Release and secrets
* It is consistent with another platform-refs, e.g. platform-ref-aws
* Randomize secret name and make it nonconflicting within a single namespace, still obviously scoped by the XR namespace
* All of the above enable this abstraction to be usable in non-Claim scenario of XAPIGateway is included into another higher-level Composition, thus no Claim based namespace mechanism is abailable/suitable here

I have:

- [ ] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

`example/claim.yaml`