### PR TITLE
Extend platform to include Deployment, Stage, DomainName, BasePathMapping

### DIFF
--- a/examples/claim.yaml
+++ b/examples/claim.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   parameters:
     region: eu-west-1
+    domain:
+      name: apigateway.upboundrocks.cloud
+      certificateArn: arn:aws:acm:eu-west-1:609897127049:certificate/9e8709a9-19b4-4f23-9c9a-83b26f951c53
     tags:
       env: test
       owner: dev

--- a/package/composition.yaml
+++ b/package/composition.yaml
@@ -108,3 +108,21 @@ spec:
           toFieldPath: spec.forProvider.restApiId
           policy:
             fromFieldPath: Required
+    - name: stage
+      base:
+        apiVersion: apigateway.aws.upbound.io/v1beta1
+        kind: Stage
+        spec:
+          forProvider:
+            stageName: prod
+            deploymentIdSelector:
+              matchControllerRef: true
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.tags
+          toFieldPath: spec.forProvider.tags
+        - fromFieldPath: status.agw.restapi-id
+          toFieldPath: spec.forProvider.restApiId
+          policy:
+            fromFieldPath: Required

--- a/package/composition.yaml
+++ b/package/composition.yaml
@@ -28,6 +28,10 @@ spec:
               kind: RestAPI
               fieldPath: status.atProvider.arn
               toConnectionSecretKey: restapi-arn
+            - apiVersion: apigateway.aws.upbound.io/v1beta1
+              kind: RestAPI
+              fieldPath: status.atProvider.id
+              toConnectionSecretKey: restapi-id
           writeConnectionSecretToRef:
             name: apigateway
             namespace: upbound-system
@@ -36,6 +40,8 @@ spec:
           toFieldPath: spec.forProvider.values.name
         - fromFieldPath: metadata.name
           toFieldPath: spec.connectionDetails[0].name
+        - fromFieldPath: metadata.name
+          toFieldPath: spec.connectionDetails[1].name
         - fromFieldPath: spec.parameters.region
           toFieldPath: spec.forProvider.values.region
         - fromFieldPath: spec.parameters.tags
@@ -83,3 +89,22 @@ spec:
               string:
                 type: Convert
                 convert: FromBase64
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.manifest.data.restapi-id
+          toFieldPath: status.agw.restapi-id
+          transforms:
+            - type: string
+              string:
+                type: Convert
+                convert: FromBase64
+    - name: deployment
+      base:
+        apiVersion: apigateway.aws.upbound.io/v1beta1
+        kind: Deployment
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: status.agw.restapi-id
+          toFieldPath: spec.forProvider.restApiId
+          policy:
+            fromFieldPath: Required

--- a/package/composition.yaml
+++ b/package/composition.yaml
@@ -126,3 +126,21 @@ spec:
           toFieldPath: spec.forProvider.restApiId
           policy:
             fromFieldPath: Required
+    - name: domain
+      base:
+        apiVersion: apigateway.aws.upbound.io/v1beta1
+        kind: DomainName
+        spec:
+          forProvider:
+            endpointConfiguration:
+              - types:
+                - REGIONAL
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: spec.parameters.tags
+          toFieldPath: spec.forProvider.tags
+        - fromFieldPath: spec.parameters.domain.name
+          toFieldPath: spec.forProvider.domainName
+        - fromFieldPath: spec.parameters.domain.certificateArn
+          toFieldPath: spec.forProvider.regionalCertificateArn

--- a/package/composition.yaml
+++ b/package/composition.yaml
@@ -144,3 +144,20 @@ spec:
           toFieldPath: spec.forProvider.domainName
         - fromFieldPath: spec.parameters.domain.certificateArn
           toFieldPath: spec.forProvider.regionalCertificateArn
+    - name: base-path-mapping
+      base:
+        apiVersion: apigateway.aws.upbound.io/v1beta1
+        kind: BasePathMapping
+        spec:
+          forProvider:
+            domainNameSelector:
+              matchControllerRef: true
+            stageNameSelector:
+              matchControllerRef: true
+      patches:
+        - fromFieldPath: spec.parameters.region
+          toFieldPath: spec.forProvider.region
+        - fromFieldPath: status.agw.restapi-id
+          toFieldPath: spec.forProvider.apiId
+          policy:
+            fromFieldPath: Required

--- a/package/definition.yaml
+++ b/package/definition.yaml
@@ -27,6 +27,18 @@ spec:
                   region:
                     type: string
                     description: AWS region
+                  domain:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        description: APIGateway domain name
+                      certificateArn:
+                        type: string
+                        description: ACM Certificate ARN
+                    required:
+                      - name
+                      - certificateArn
                   tags:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
@@ -93,6 +105,7 @@ spec:
                               - authorizationType
                 required:
                   - region
+                  - domain
             required:
               - parameters
           status:


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

Extend platform to include Deployment, Stage, DomainName, BasePathMapping

Important: Deployment(and rest of the resources) should be created after 'core' APIGateway Resources (RestAPI + all the Methods and Integrations). See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/api_gateway_deployment

That's why we order Deployment creation in the main Composition with policy `fromFieldPath: required` to instantiate the Deploument strictly after the core resources that are driven by abstracted helm chart. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [ ] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

```
k get -f examples/claim.yaml
NAME                 SYNCED   READY   CONNECTION-SECRET   AGE
upbound-apigateway   True     True                        25m
```
